### PR TITLE
No range feature implementation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+.eggs
 *.egg-info
 dist
 build

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ output/*/index.html
 
 # Sphinx
 #docs/_build
+
+# Venv
+venv/*
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,6 @@ output/*/index.html
 
 # Venv
 venv/*
+
+# VSCode editor
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ output/*/index.html
 # Sphinx
 #docs/_build
 
+# Mac OS
+.DS_store
+
 # Venv
 venv/*
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ Contributors
 * Machine-Hum
 * anton
 * Stefan Hamminga
+* Scott Candey

--- a/kifield/__main__.py
+++ b/kifield/__main__.py
@@ -89,6 +89,14 @@ def main():
         ),
     )
     parser.add_argument(
+        "--norange",
+        "-nr",
+        action="store_true",
+        help=(
+            "Disable hyphenated ranges when components are grouped, explicitly showing each component in a group."
+        ),
+    )
+    parser.add_argument(
         "--debug",
         "-d",
         nargs="?",
@@ -144,6 +152,7 @@ def main():
         inc_field_names=inc_fields,
         exc_field_names=exc_fields,
         group_components=args.group,
+        no_range=args.norange,
         recurse=args.recurse,
         backup=not args.nobackup,
     )

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -1514,7 +1514,7 @@ def insert_part_fields(part_fields_dict, filenames, recurse, group_components, b
         else:
             try:
                 insertion_function(
-                    part_fields_dict, f, recurse, group_components, backup
+                    part_fields_dict, f, recurse, group_components, backup, no_range
                 )
 
             except IOError:

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -79,7 +79,7 @@ def wb_to_csvfile(wb, csv_filename, dialect):
             writer.writerow([cell.value for cell in row])
 
 
-def group_wb(wb):
+def group_wb(wb, no_range=False):
     """Group lines that have the same column values in a openpyxl workbook.
     Headers are expected on the first row and references are expected in the
     first column."""
@@ -875,7 +875,7 @@ def insert_part_fields_into_wb(part_fields_dict, wb, recurse=False):
 
 
 def insert_part_fields_into_xlsx(
-    part_fields_dict, filename, recurse, group_components, backup
+    part_fields_dict, filename, recurse, group_components, backup, no_range
 ):
     """Insert the fields in the extracted part dictionary into an XLSX spreadsheet."""
 
@@ -895,13 +895,13 @@ def insert_part_fields_into_xlsx(
     wb = insert_part_fields_into_wb(part_fields_dict, wb)
 
     if group_components:
-        wb = group_wb(wb)
+        wb = group_wb(wb, no_range)
 
     wb.save(filename)
 
 
 def insert_part_fields_into_csv(
-    part_fields_dict, filename, recurse, group_components, backup
+    part_fields_dict, filename, recurse, group_components, backup, no_range
 ):
     """Insert the fields in the extracted part dictionary into a CSV spreadsheet."""
 
@@ -925,7 +925,7 @@ def insert_part_fields_into_csv(
     wb = insert_part_fields_into_wb(part_fields_dict, wb)
 
     if group_components:
-        wb = group_wb(wb)
+        wb = group_wb(wb, no_range)
 
     wb_to_csvfile(wb, filename, dialect)
 
@@ -1464,7 +1464,7 @@ def insert_part_fields_into_dcm(
     dcm.save(filename)
 
 
-def insert_part_fields(part_fields_dict, filenames, recurse, group_components, backup):
+def insert_part_fields(part_fields_dict, filenames, recurse, group_components, backup, no_range):
     """Insert part fields from a dictionary into a spreadsheet, part library, or schematic."""
 
     # No files backed-up yet, so clear list of file names.
@@ -1546,5 +1546,5 @@ def kifield(
 
     # Insert entries from the dictionary into these files.
     insert_part_fields(
-        part_fields_dict, insert_filenames, recurse, group_components, backup
+        part_fields_dict, insert_filenames, recurse, group_components, backup, no_range
     )

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -107,7 +107,10 @@ def group_wb(wb):
 
     grouped_rows = []
     for i, ref in enumerate(references):
-        grouped_rows.append((collapse(ref),) + unique_rows[i])
+        if no_range:
+            grouped_rows.append((ref,) + unique_rows[i])
+        else:
+            grouped_rows.append((collapse(ref),) + unique_rows[i])
 
     grouped_wb = pyxl.Workbook()
     grouped_ws = grouped_wb.active
@@ -1530,6 +1533,7 @@ def kifield(
     recurse=False,
     group_components=False,
     backup=True,
+    no_range=False
 ):
     """Extract fields from a set of files and insert them into another set of files."""
 

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -107,8 +107,9 @@ def group_wb(wb, no_range=False):
 
     grouped_rows = []
     for i, ref in enumerate(references):
+        # If no_range flag, do a simple join on the references assuming already sorted?
         if no_range:
-            grouped_rows.append((ref,) + unique_rows[i])
+            grouped_rows.append((', '.join(ref),) + unique_rows[i])
         else:
             grouped_rows.append((collapse(ref),) + unique_rows[i])
 

--- a/kifield/kifield.py
+++ b/kifield/kifield.py
@@ -107,9 +107,12 @@ def group_wb(wb, no_range=False):
 
     grouped_rows = []
     for i, ref in enumerate(references):
-        # If no_range flag, do a simple join on the references assuming already sorted?
+        # If no_range flag, do the collapse to ensure sorting, then explode, then join to string
         if no_range:
-            grouped_rows.append((', '.join(ref),) + unique_rows[i])
+            collapsed_refs = collapse(ref)
+            exploded_refs = explode(collapsed_refs)
+            joined_refs = (', ').join(exploded_refs)
+            grouped_rows.append((joined_refs,) + unique_rows[i])
         else:
             grouped_rows.append((collapse(ref),) + unique_rows[i])
 

--- a/tests/integration/test.mk
+++ b/tests/integration/test.mk
@@ -181,15 +181,15 @@ test11:
     # Copy the CAT schematic file.
 	@cp CAT.sch $@.sch
     # Get the grouped (no ranges) fields from the schematic into the CSV file.
-	@$(PROG) -g -nr -x $@.sch -i $@.csv $(FLAGS)
+	@$(PROG) -r -g -nr -x $@.sch -i $@.csv $(FLAGS)
     # Add some random columns of random stuff to the CSV file.
 	@python randomizer.py $@.csv $@.csv
     # Insert the random stuff back into the fields of the schematic.
 	@$(PROG) -x $@.csv -i $@.sch $(FLAGS)
     # Extract the updated grouped (no ranges) fields from the schematic into an XLSX file.
-	@$(PROG) -g -nr -x $@.sch -i $@.xlsx $(FLAGS)
+	@$(PROG) -r -g -nr -x $@.sch -i $@.xlsx $(FLAGS)
     # Extract the grouped (no ranges) contents of the XLSX file into a CSV file.
-	@$(PROG) -g -nr -x $@.xlsx -i $@1.csv $(FLAGS)
+	@$(PROG) -r -g -nr -x $@.xlsx -i $@1.csv $(FLAGS)
     # The extracted CSV file should match the randomized CSV file.
 	@diff -qsw $@.csv $@1.csv
 	@echo 'Test $@ passed!'

--- a/tests/integration/test.mk
+++ b/tests/integration/test.mk
@@ -2,7 +2,7 @@ PROG = kifield
 #PROG = python -m ..\..\kifield
 FLAGS = -w -nb -d 1
 
-test: test1 test2 test3 test4 test5 test6 test7 test8 test9
+test: test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11
 	@echo 'All tests passed!'
 	@$(PROG) -v
 
@@ -162,7 +162,39 @@ test9:
 	@diff -qsw $@.csv $@1.csv
 	@echo 'Test $@ passed!'
 
+test10:
+	@rm -f $@*.*
+    # Copy the CAT schematic file.
+	@cp CAT.sch $@.sch
+    # Get the grouped fields from the schematic into the CSV file, no ranges
+	@$(PROG) -g -nr -x $@.sch -i $@.csv $(FLAGS)
+    # Make a copy of the grouped fields.
+	@cp $@.csv $@1.csv
+    # Extract the grouped fields and add them to the copy.
+	@$(PROG) -g -nr -x $@.sch -i $@1.csv $(FLAGS)
+    # The extracted CSV file should match the initial CSV file.
+	@diff -qsw $@.csv $@1.csv
+	@echo 'Test $@ passed!'
+
+test11:
+	@rm -f $@*.*
+    # Copy the CAT schematic file.
+	@cp CAT.sch $@.sch
+    # Get the grouped (no ranges) fields from the schematic into the CSV file.
+	@$(PROG) -g -nr -x $@.sch -i $@.csv $(FLAGS)
+    # Add some random columns of random stuff to the CSV file.
+	@python randomizer.py $@.csv $@.csv
+    # Insert the random stuff back into the fields of the schematic.
+	@$(PROG) -x $@.csv -i $@.sch $(FLAGS)
+    # Extract the updated grouped (no ranges) fields from the schematic into an XLSX file.
+	@$(PROG) -g -nr -x $@.sch -i $@.xlsx $(FLAGS)
+    # Extract the grouped (no ranges) contents of the XLSX file into a CSV file.
+	@$(PROG) -g -nr -x $@.xlsx -i $@1.csv $(FLAGS)
+    # The extracted CSV file should match the randomized CSV file.
+	@diff -qsw $@.csv $@1.csv
+	@echo 'Test $@ passed!'
+
 
 clean:
-	@rm -f test[1-9]*.* *.bak
+	@rm -f test[1-11]*.* *.bak
 	@echo 'Cleanup complete.'

--- a/tests/unit/test_group_wb.py
+++ b/tests/unit/test_group_wb.py
@@ -46,3 +46,25 @@ def test_groups2():
     assert values[3] == ("X1", "3", "1", "1")
     assert values[4] == ("X2", "1", "3", "1")
     assert values[5] == ("X3", "1", "1", "3")
+
+
+# Test for no-range flag
+def test_groups3():
+    wb = pyxl.Workbook()
+    ws = wb.active
+    header = ("Ref", "x", "y", "z")
+    ws.append(header)
+    ws.append(("C1", "1", "1", "1"))
+    ws.append(("C2", "1", "1", "1"))
+    ws.append(("C3", "1", "1", "1"))
+
+    no_range = True
+    wb = kifield.group_wb(wb)
+    ws = wb.active
+
+    assert ws.max_row == 2
+    assert ws.max_column == 4
+
+    values = tuple(ws.values)
+    assert values[0] == header
+    assert values[1] == ("C1,C2,C3", "1", "1", "1")

--- a/tests/unit/test_group_wb.py
+++ b/tests/unit/test_group_wb.py
@@ -58,8 +58,7 @@ def test_groups3():
     ws.append(("C2", "1", "1", "1"))
     ws.append(("C3", "1", "1", "1"))
 
-    no_range = True
-    wb = kifield.group_wb(wb)
+    wb = kifield.group_wb(wb, no_range=True)
     ws = wb.active
 
     assert ws.max_row == 2

--- a/tests/unit/test_group_wb.py
+++ b/tests/unit/test_group_wb.py
@@ -66,4 +66,4 @@ def test_groups3():
 
     values = tuple(ws.values)
     assert values[0] == header
-    assert values[1] == ("C1,C2,C3", "1", "1", "1")
+    assert values[1] == ("C1, C2, C3", "1", "1", "1")


### PR DESCRIPTION
Added flag --norange, -nr as new argument in main.py
Added internal flag `no_range` for use in kifield.py
Implemented no_range behavior by collapsing all references, exploding the collapsed references, and then joining the resulting sorted and explicit list of references to make a nice string.
Added unit test for the edited group_wb method
Added two integration tests based on existing tests of grouping and randomizing.

Added self to contributors list.
Added a handful of items to .gitignore to cover my environment.

The result passes all of the tests (for Python 2.7 and 3.9, which is what I already had installed). It also seems to consistently work for my overly complex schematic in progress. 

Did not edit the readme or rebuild the docs for this pull request, I couldn't figure out how to get the docs to build properly.

(I am happy to squash all those commits down to one if that would be easier to merge)